### PR TITLE
Добавить HTTP API для ТaskManager

### DIFF
--- a/.idea/libraries/gson_2_9_0.xml
+++ b/.idea/libraries/gson_2_9_0.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="gson-2.9.0">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/Documents/Libraries/gson-2.9.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/java-kanban.iml
+++ b/java-kanban.iml
@@ -40,5 +40,6 @@
         <SOURCES />
       </library>
     </orderEntry>
+    <orderEntry type="library" name="gson-2.9.0" level="project" />
   </component>
 </module>

--- a/src/Main.java
+++ b/src/Main.java
@@ -24,13 +24,19 @@ public class Main {
         tm.addSubtask(new Subtask(2, 3, "сборка", "упаковать вещи", Status.IN_PROGRESS,
                 Duration.ofMinutes(90), LocalDateTime.now()));
 
-        System.out.println("Приоритетные задачи:");
+        tm.getTask(1);
+        tm.getEpic(2);
+        tm.getSubtask(3);
+
+        System.out.println("========== история просмотра ==========");
+        tm.getHistory().forEach(System.out::println);
+        System.out.println();
+
+        System.out.println(" ========== приоритетные задачи ==========");
         tm.getPrioritizedTasks().forEach(System.out::println);
-
-        System.out.println();
-        System.out.println("========== просмотр файла ========== ");
         System.out.println();
 
+        System.out.println("========== просмотр файла ==========");
         FileBackedTaskManager load = FileBackedTaskManager.loadFromFile(file);
         printAllTasks(load);
 

--- a/src/tracker/exceptions/NotFoundException.java
+++ b/src/tracker/exceptions/NotFoundException.java
@@ -1,0 +1,8 @@
+package tracker.exceptions;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}
+

--- a/src/tracker/interfaces/HistoryManager.java
+++ b/src/tracker/interfaces/HistoryManager.java
@@ -10,5 +10,7 @@ public interface HistoryManager {
 
     void remove(int id);
 
+    void clear();
+
     List<Task> getHistory();
 }

--- a/src/tracker/interfaces/TaskManager.java
+++ b/src/tracker/interfaces/TaskManager.java
@@ -19,13 +19,6 @@ public interface TaskManager {
 
     List<Subtask> getSubtasks();
 
-    // Удаление задач
-    void deleteTasks();
-
-    void deleteEpics();
-
-    void deleteSubtasks();
-
     // Получение по идентификатору
     Task getTask(int id);
 
@@ -54,4 +47,14 @@ public interface TaskManager {
     void deleteEpicById(int id);
 
     void deleteSubtaskById(Integer id);
+
+    // Удаление задач
+    void deleteTasks();
+
+    void deleteEpics();
+
+    void deleteSubtasks();
+
+    // Удаление всех задач, эпиков и подзадач
+    void clearAll();
 }

--- a/src/tracker/managers/InMemoryHistoryManager.java
+++ b/src/tracker/managers/InMemoryHistoryManager.java
@@ -40,6 +40,11 @@ public class InMemoryHistoryManager implements HistoryManager {
         return tasks;
     }
 
+    @Override
+    public void clear() {
+        this.history.clear();
+    }
+
     private void linkLast(Task task) {
         if (history.containsKey(task.getId())) {
             removeNode(history.get(task.getId()));

--- a/src/tracker/managers/InMemoryTaskManager.java
+++ b/src/tracker/managers/InMemoryTaskManager.java
@@ -1,6 +1,7 @@
 package tracker.managers;
 
 import tracker.constants.Status;
+import tracker.exceptions.NotFoundException;
 import tracker.interfaces.HistoryManager;
 import tracker.interfaces.TaskManager;
 import tracker.model.Epic;
@@ -21,11 +22,13 @@ public class InMemoryTaskManager implements TaskManager {
             Comparator.nullsLast(Comparator.naturalOrder())));
     private int nextId = 1;
 
+    // Получение приоритетных задач
     @Override
     public List<Task> getPrioritizedTasks() {
         return new ArrayList<>(prioritizedTasks);
     }
 
+    // Проверка пересечения по времени
     private boolean hasNoIntersection(Task task) {
         return prioritizedTasks.stream()
                 .noneMatch(pTask -> {
@@ -122,18 +125,27 @@ public class InMemoryTaskManager implements TaskManager {
     // Получение по идентификатору
     @Override
     public Task getTask(int id) {
+        if (tasks.get(id) == null) {
+            throw new NotFoundException("Задача с ID " + id + " не найдена");
+        }
         historyManager.add(tasks.get(id));
         return tasks.get(id);
     }
 
     @Override
     public Epic getEpic(int id) {
+        if (epics.get(id) == null) {
+            throw new NotFoundException("Эпик с ID " + id + " не найдена");
+        }
         historyManager.add(epics.get(id));
         return epics.get(id);
     }
 
     @Override
     public Subtask getSubtask(int id) {
+        if (subtasks.get(id) == null) {
+            throw new NotFoundException("Подзадача с ID " + id + " не найдена");
+        }
         historyManager.add(subtasks.get(id));
         return subtasks.get(id);
     }
@@ -143,6 +155,10 @@ public class InMemoryTaskManager implements TaskManager {
     @Override
     public List<Subtask> getEpicSubtasks(int epicId) {
         Epic epic = epics.get(epicId);
+        if (epic == null) {
+            throw new NotFoundException("Эпик не найдена");
+        }
+
         return epic.getSubtasksIds()
                 .stream()
                 .map(subtasks::get)
@@ -175,6 +191,9 @@ public class InMemoryTaskManager implements TaskManager {
         if (hasNoIntersection(subtask)) {
             subtask.setId(nextId++);
             Epic epic = epics.get(subtask.getEpicId());
+            if (epic == null) {
+                throw new NotFoundException("Эпик не найдена");
+            }
             epic.getSubtasksIds().add(subtask.getId());
             subtasks.put(subtask.getId(), subtask);
             updateEpicStatus(epic.getId());
@@ -235,6 +254,10 @@ public class InMemoryTaskManager implements TaskManager {
     public void deleteEpicById(int id) {
         historyManager.remove(id);
         Epic epic = epics.get(id);
+        if (epic == null) {
+            throw new NotFoundException("Эпик не найдена");
+        }
+
         for (Integer subtaskId : epic.getSubtasksIds()) {
             prioritizedTasks.remove(getSubtask(subtaskId));
             historyManager.remove(subtaskId);
@@ -245,6 +268,9 @@ public class InMemoryTaskManager implements TaskManager {
 
     @Override
     public void deleteSubtaskById(Integer id) {
+        if (subtasks.get(id) == null) {
+            throw new NotFoundException("Подзадача не найдена");
+        }
         Epic epic = epics.get(subtasks.get(id).getEpicId());
         epic.getSubtasksIds().remove(id);
         updateEpicStatus(epic.getId());
@@ -291,6 +317,39 @@ public class InMemoryTaskManager implements TaskManager {
             prioritizedTasks.remove(getSubtask(id));
         }
         subtasks.clear();
+    }
+
+    @Override
+    public void clearAll() {
+        // Очищаем подзадачи
+        for (Epic epic : epics.values()) {
+            epic.cleanSubtaskIds();
+            updateEpicStatus(epic.getId());
+            updateEpicTime(epic.getId());
+        }
+
+        for (int id : subtasks.keySet()) {
+            historyManager.remove(id);
+            prioritizedTasks.remove(getSubtask(id));
+        }
+        subtasks.clear();
+
+        // Очищаем эпики
+        for (int id : epics.keySet()) {
+            historyManager.remove(id);
+        }
+        epics.clear();
+
+        // Очищаем обычные задачи
+        for (int id : tasks.keySet()) {
+            historyManager.remove(id);
+            prioritizedTasks.remove(getTask(id));
+        }
+        tasks.clear();
+
+        // Очищаем историю и приоритетные задачи
+        historyManager.clear();
+        prioritizedTasks.clear();
     }
 
 }

--- a/src/tracker/model/Epic.java
+++ b/src/tracker/model/Epic.java
@@ -9,6 +9,10 @@ public class Epic extends Task {
     private final ArrayList<Integer> subtasksIds = new ArrayList<>();
     private LocalDateTime endTime;
 
+    public Epic(String title, String description) {
+        super(title, description);
+    }
+
     public Epic(int id, String title, String description) {
         super(id, title, description);
     }

--- a/src/tracker/model/Subtask.java
+++ b/src/tracker/model/Subtask.java
@@ -9,6 +9,12 @@ import java.time.LocalDateTime;
 public class Subtask extends Task {
     private final int epicId;
 
+    public Subtask(int epicId, String title, String description, Status status, Duration duration,
+                   LocalDateTime startTime) {
+        super(title, description, status, duration, startTime);
+        this.epicId = epicId;
+    }
+
     public Subtask(int epicId, int id, String title, String description, Status status, Duration duration,
                    LocalDateTime startTime) {
         super(id, title, description, status, duration, startTime);

--- a/src/tracker/model/Task.java
+++ b/src/tracker/model/Task.java
@@ -15,6 +15,17 @@ public class Task {
     protected Duration duration;
     protected LocalDateTime startTime;
 
+    public Task(String title, String description) {
+        this.title = title;
+        this.description = description;
+    }
+
+    public Task(int id, String title, String description) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+    }
+
     public Task(int id, String title, String description, Status status, Duration duration, LocalDateTime startTime) {
         this.id = id;
         this.title = title;
@@ -24,10 +35,12 @@ public class Task {
         this.startTime = startTime;
     }
 
-    public Task(int id, String title, String description) {
-        this.id = id;
+    public Task(String title, String description, Status status, Duration duration, LocalDateTime startTime) {
         this.title = title;
         this.description = description;
+        this.status = status;
+        this.duration = duration;
+        this.startTime = startTime;
     }
 
     @Override

--- a/src/tracker/server/HttpTaskServer.java
+++ b/src/tracker/server/HttpTaskServer.java
@@ -1,0 +1,67 @@
+package tracker.server;
+
+import com.sun.net.httpserver.HttpServer;
+import tracker.interfaces.TaskManager;
+import tracker.managers.Managers;
+import tracker.server.handlers.*;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+public class HttpTaskServer {
+
+    private static final int PORT = 8080;
+
+    private final HttpServer server;
+
+    public HttpTaskServer() throws IOException {
+        this(Managers.getDefault());
+    }
+
+    public HttpTaskServer(TaskManager taskManager) throws IOException {
+        server = HttpServer.create(new InetSocketAddress(PORT), 0);
+        server.createContext("/tasks", new TasksHandler(taskManager));
+        server.createContext("/epics", new EpicsHandler(taskManager));
+        server.createContext("/subtasks", new SubtasksHandler(taskManager));
+        server.createContext("/history", new HistoryHandler(taskManager));
+        server.createContext("/prioritized", new PrioritizedHandler(taskManager));
+    }
+
+    public static void main(String[] args) {
+        try {
+            HttpTaskServer server = new HttpTaskServer();
+            server.start();
+            System.out.println("Сервер запущен по адресу: http://localhost:" + PORT);
+
+            System.out.println("Доступные пути:");
+            System.out.println("Задачи:");
+            System.out.println("- /tasks");
+            System.out.println("- /tasks/{id}");
+            System.out.println("Эпики:");
+            System.out.println("- /epics");
+            System.out.println("- /epics/{id}");
+            System.out.println("- /epics/{id}/subtasks");
+            System.out.println("Подзадачи:");
+            System.out.println("- /subtasks");
+            System.out.println("- /subtasks/{id}");
+            System.out.println("История:");
+            System.out.println("- /history");
+            System.out.println("Приоритетный задачи:");
+            System.out.println("- /prioritized");
+
+            server.stop();
+            System.out.println("Сервер остановлен на порту: " + PORT);
+        } catch (IOException e) {
+            System.out.println("Ошибка при запуске сервера: " + e.getMessage());
+        }
+    }
+
+    public void start() throws IOException {
+        server.start();
+    }
+
+    public void stop() {
+        server.stop(0);
+    }
+}
+

--- a/src/tracker/server/handlers/AbstractRequestHandler.java
+++ b/src/tracker/server/handlers/AbstractRequestHandler.java
@@ -1,0 +1,34 @@
+package tracker.server.handlers;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.IOException;
+
+public abstract class AbstractRequestHandler implements HttpHandler {
+
+    protected abstract void handleGet(HttpExchange exchange, String path) throws IOException;
+
+    protected abstract void handlePost(HttpExchange exchange, String path) throws IOException;
+
+    protected abstract void handleDelete(HttpExchange exchange, String path) throws IOException;
+
+    @Override
+    public void handle(HttpExchange exchange) {
+        try {
+            String requestMethod = exchange.getRequestMethod().toUpperCase();
+            String path = exchange.getRequestURI().getPath();
+
+            switch (requestMethod) {
+                case "GET" -> handleGet(exchange, path);
+                case "POST" -> handlePost(exchange, path);
+                case "DELETE" -> handleDelete(exchange, path);
+                default -> exchange.sendResponseHeaders(405, 0);
+            }
+        } catch (IOException e) {
+            System.err.println("Произошла ошибка: " + e.getMessage());
+        }
+
+    }
+
+}

--- a/src/tracker/server/handlers/AbstractRequestHandler.java
+++ b/src/tracker/server/handlers/AbstractRequestHandler.java
@@ -4,17 +4,30 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 
 import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public abstract class AbstractRequestHandler implements HttpHandler {
+    private static final Logger logger = Logger.getLogger(AbstractRequestHandler.class.getName());
 
-    protected abstract void handleGet(HttpExchange exchange, String path) throws IOException;
+    protected void handleGet(HttpExchange exchange, String path) throws IOException {
+        sendMethodNotAllowed(exchange);
+    }
 
-    protected abstract void handlePost(HttpExchange exchange, String path) throws IOException;
+    protected void handlePost(HttpExchange exchange, String path) throws IOException {
+        sendMethodNotAllowed(exchange);
+    }
 
-    protected abstract void handleDelete(HttpExchange exchange, String path) throws IOException;
+    protected void handleDelete(HttpExchange exchange, String path) throws IOException {
+        sendMethodNotAllowed(exchange);
+    }
+
+    private void sendMethodNotAllowed(HttpExchange exchange) throws IOException {
+        exchange.sendResponseHeaders(405, 0);
+    }
 
     @Override
-    public void handle(HttpExchange exchange) {
+    public void handle(HttpExchange exchange) throws IOException {
         try {
             String requestMethod = exchange.getRequestMethod().toUpperCase();
             String path = exchange.getRequestURI().getPath();
@@ -26,9 +39,9 @@ public abstract class AbstractRequestHandler implements HttpHandler {
                 default -> exchange.sendResponseHeaders(405, 0);
             }
         } catch (IOException e) {
-            System.err.println("Произошла ошибка: " + e.getMessage());
+            logger.log(Level.SEVERE, "Ошибка при обработке HTTP запроса", e);
+            throw e;
         }
-
     }
 
 }

--- a/src/tracker/server/handlers/BaseHttpHandler.java
+++ b/src/tracker/server/handlers/BaseHttpHandler.java
@@ -1,0 +1,92 @@
+package tracker.server.handlers;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.sun.net.httpserver.HttpExchange;
+import tracker.interfaces.TaskManager;
+import tracker.server.handlers.adapters.DurationAdapter;
+import tracker.server.handlers.adapters.LocalDateTimeAdapter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+public abstract class BaseHttpHandler extends AbstractRequestHandler {
+    public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+    protected final TaskManager taskManager;
+    protected final Gson gson;
+
+    protected BaseHttpHandler(TaskManager taskManager) {
+        this.taskManager = taskManager;
+        this.gson = createGson();
+    }
+
+    public static Gson createGson() {
+        return new GsonBuilder()
+                .serializeNulls()
+                .setPrettyPrinting()
+                .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeAdapter())
+                .registerTypeAdapter(Duration.class, new DurationAdapter())
+                .create();
+    }
+
+
+    protected String readText(HttpExchange h) throws IOException {
+        return new String(h.getRequestBody().readAllBytes(), DEFAULT_CHARSET);
+    }
+
+    protected void sendJson(HttpExchange h, Object data, int responseCode) throws IOException {
+        String json = gson.toJson(data);
+        byte[] resp = json.getBytes(DEFAULT_CHARSET);
+
+        h.getResponseHeaders().set("Content-Type", "application/json;charset=utf-8");
+        h.sendResponseHeaders(responseCode, resp.length);
+
+        try (OutputStream os = h.getResponseBody()) {
+            os.write(resp);
+        }
+    }
+
+    protected void sendBadRequest(HttpExchange h) throws IOException {
+        h.getResponseHeaders().set("Content-Type", "application/json;charset=utf-8");
+        h.sendResponseHeaders(400, 0);
+
+        try (OutputStream os = h.getResponseBody()) {
+            String errorMessage = "{\"error\": \"Некорректный запрос\"}";
+            os.write(errorMessage.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    protected void sendNotFound(HttpExchange h) throws IOException {
+        h.getResponseHeaders().set("Content-Type", "application/json;charset=utf-8");
+        h.sendResponseHeaders(404, 0);
+
+        try (h; OutputStream os = h.getResponseBody()) {
+            String errorMessage = "{\"error\": \"Ресурс не найден\"}";
+            os.write(errorMessage.getBytes(DEFAULT_CHARSET));
+        }
+    }
+
+    protected void sendIntersection(HttpExchange h) throws IOException {
+        h.getResponseHeaders().set("Content-Type", "application/json;charset=utf-8");
+        h.sendResponseHeaders(409, 0);
+
+        try (OutputStream os = h.getResponseBody()) {
+            String errorMessage = "{\"error\": \"Пересечение по времени\"}";
+            os.write(errorMessage.getBytes(DEFAULT_CHARSET));
+        }
+    }
+
+    protected void sendInternalError(HttpExchange h) throws IOException {
+        h.getResponseHeaders().set("Content-Type", "application/json;charset=utf-8");
+        h.sendResponseHeaders(500, 0);
+
+        try (OutputStream os = h.getResponseBody()) {
+            String errorMessage = "{\"error\": \"Внутренняя ошибка сервера\"}";
+            os.write(errorMessage.getBytes(DEFAULT_CHARSET));
+        }
+    }
+}

--- a/src/tracker/server/handlers/EpicsHandler.java
+++ b/src/tracker/server/handlers/EpicsHandler.java
@@ -1,0 +1,95 @@
+package tracker.server.handlers;
+
+import com.sun.net.httpserver.HttpExchange;
+import tracker.exceptions.NotFoundException;
+import tracker.interfaces.TaskManager;
+import tracker.model.Epic;
+
+import java.io.IOException;
+
+public class EpicsHandler extends BaseHttpHandler {
+
+    public EpicsHandler(TaskManager taskManager) {
+        super(taskManager);
+    }
+
+    @Override
+    protected void handleGet(HttpExchange exchange, String path) throws IOException {
+        try {
+            if (path.equals("/epics")) {
+                sendJson(exchange, taskManager.getEpics(), 200);
+            } else if (path.startsWith("/epics/")) {
+                if (path.contains("/subtasks")) {
+                    String epicIdStr = path.substring("/epics/".length(), path.indexOf("/subtasks"));
+                    int epicId = Integer.parseInt(epicIdStr);
+                    sendJson(exchange, taskManager.getEpicSubtasks(epicId), 200);
+                } else {
+                    String epicIdStr = path.substring("/epics/".length());
+                    int epicId = Integer.parseInt(epicIdStr);
+                    sendJson(exchange, taskManager.getEpic(epicId), 200);
+                }
+            } else {
+                sendNotFound(exchange);
+            }
+        } catch (NumberFormatException e) {
+            sendBadRequest(exchange);
+        } catch (NotFoundException e) {
+            sendNotFound(exchange);
+        } catch (Exception e) {
+            sendInternalError(exchange);
+        }
+    }
+
+    @Override
+    protected void handlePost(HttpExchange exchange, String path) throws IOException {
+        try {
+            if (path.equals("/epics")) {
+                String requestBody = readText(exchange);
+                Epic epic = gson.fromJson(requestBody, Epic.class);
+
+                if (epic == null) {
+                    sendBadRequest(exchange);
+                    return;
+                }
+
+                taskManager.addEpic(epic);
+                exchange.getResponseHeaders().set("Location", "/epics/" + epic.getId());
+                sendJson(exchange, epic, 201);
+            } else {
+                sendNotFound(exchange);
+            }
+        } catch (NumberFormatException e) {
+            sendBadRequest(exchange);
+        } catch (NotFoundException e) {
+            sendNotFound(exchange);
+        } catch (Exception e) {
+            sendInternalError(exchange);
+        }
+    }
+
+    @Override
+    protected void handleDelete(HttpExchange exchange, String path) throws IOException {
+        try {
+            if (!path.startsWith("/epics/")) {
+                sendNotFound(exchange);
+                return;
+            }
+
+            String epicIdStr = path.substring("/epics/".length());
+            if (epicIdStr.isEmpty()) {
+                sendBadRequest(exchange);
+                return;
+            }
+
+            int epicId = Integer.parseInt(epicIdStr);
+            taskManager.deleteEpicById(epicId);
+            sendJson(exchange, null, 200);
+        } catch (NumberFormatException e) {
+            sendBadRequest(exchange);
+        } catch (NotFoundException e) {
+            sendNotFound(exchange);
+        } catch (Exception e) {
+            sendInternalError(exchange);
+        }
+    }
+}

--- a/src/tracker/server/handlers/HistoryHandler.java
+++ b/src/tracker/server/handlers/HistoryHandler.java
@@ -23,15 +23,4 @@ public class HistoryHandler extends BaseHttpHandler {
             sendInternalError(exchange);
         }
     }
-
-
-    @Override
-    protected void handlePost(HttpExchange exchange, String path) {
-        throw new UnsupportedOperationException("Метод не поддерживается");
-    }
-
-    @Override
-    protected void handleDelete(HttpExchange exchange, String path) {
-        throw new UnsupportedOperationException("Метод не поддерживается");
-    }
 }

--- a/src/tracker/server/handlers/HistoryHandler.java
+++ b/src/tracker/server/handlers/HistoryHandler.java
@@ -1,0 +1,37 @@
+package tracker.server.handlers;
+
+import com.sun.net.httpserver.HttpExchange;
+import tracker.interfaces.TaskManager;
+
+import java.io.IOException;
+
+public class HistoryHandler extends BaseHttpHandler {
+
+    public HistoryHandler(TaskManager taskManager) {
+        super(taskManager);
+    }
+
+    @Override
+    protected void handleGet(HttpExchange exchange, String path) throws IOException {
+        try {
+            if (path.equals("/history")) {
+                sendJson(exchange, taskManager.getHistory(), 200);
+            } else {
+                sendNotFound(exchange);
+            }
+        } catch (Exception e) {
+            sendInternalError(exchange);
+        }
+    }
+
+
+    @Override
+    protected void handlePost(HttpExchange exchange, String path) {
+        throw new UnsupportedOperationException("Метод не поддерживается");
+    }
+
+    @Override
+    protected void handleDelete(HttpExchange exchange, String path) {
+        throw new UnsupportedOperationException("Метод не поддерживается");
+    }
+}

--- a/src/tracker/server/handlers/PrioritizedHandler.java
+++ b/src/tracker/server/handlers/PrioritizedHandler.java
@@ -1,0 +1,36 @@
+package tracker.server.handlers;
+
+import com.sun.net.httpserver.HttpExchange;
+import tracker.interfaces.TaskManager;
+
+import java.io.IOException;
+
+public class PrioritizedHandler extends BaseHttpHandler {
+
+    public PrioritizedHandler(TaskManager taskManager) {
+        super(taskManager);
+    }
+
+    @Override
+    protected void handleGet(HttpExchange exchange, String path) throws IOException {
+        try {
+            if (path.equals("/prioritized")) {
+                sendJson(exchange, taskManager.getPrioritizedTasks(), 200);
+            } else {
+                sendNotFound(exchange);
+            }
+        } catch (Exception e) {
+            sendInternalError(exchange);
+        }
+    }
+
+    @Override
+    protected void handlePost(HttpExchange exchange, String path) {
+        throw new UnsupportedOperationException("Метод не поддерживается");
+    }
+
+    @Override
+    protected void handleDelete(HttpExchange exchange, String path) {
+        throw new UnsupportedOperationException("Метод не поддерживается");
+    }
+}

--- a/src/tracker/server/handlers/PrioritizedHandler.java
+++ b/src/tracker/server/handlers/PrioritizedHandler.java
@@ -24,13 +24,4 @@ public class PrioritizedHandler extends BaseHttpHandler {
         }
     }
 
-    @Override
-    protected void handlePost(HttpExchange exchange, String path) {
-        throw new UnsupportedOperationException("Метод не поддерживается");
-    }
-
-    @Override
-    protected void handleDelete(HttpExchange exchange, String path) {
-        throw new UnsupportedOperationException("Метод не поддерживается");
-    }
 }

--- a/src/tracker/server/handlers/SubtasksHandler.java
+++ b/src/tracker/server/handlers/SubtasksHandler.java
@@ -1,0 +1,110 @@
+package tracker.server.handlers;
+
+import com.sun.net.httpserver.HttpExchange;
+import tracker.exceptions.NotFoundException;
+import tracker.interfaces.TaskManager;
+import tracker.model.Epic;
+import tracker.model.Subtask;
+
+import java.io.IOException;
+
+public class SubtasksHandler extends BaseHttpHandler {
+
+    public SubtasksHandler(TaskManager taskManager) {
+        super(taskManager);
+    }
+
+    @Override
+    protected void handleGet(HttpExchange exchange, String path) throws IOException {
+        try {
+            if (path.equals("/subtasks")) {
+                sendJson(exchange, taskManager.getSubtasks(), 200);
+            } else if (path.startsWith("/subtasks/")) {
+                String subtaskIdStr = path.substring("/subtasks/".length());
+
+                if (subtaskIdStr.isEmpty()) {
+                    sendBadRequest(exchange);
+                    return;
+                }
+
+                int subtaskId = Integer.parseInt(subtaskIdStr);
+                sendJson(exchange, taskManager.getSubtask(subtaskId), 200);
+            } else {
+                sendNotFound(exchange);
+            }
+        } catch (NotFoundException e) {
+            sendNotFound(exchange);
+        } catch (NumberFormatException e) {
+            sendBadRequest(exchange);
+        } catch (Exception e) {
+            sendInternalError(exchange);
+        }
+    }
+
+    @Override
+    protected void handlePost(HttpExchange exchange, String path) throws IOException {
+        try {
+            if (path.equals("/subtasks")) {
+                String requestBody = readText(exchange);
+
+                if (requestBody == null || requestBody.isEmpty()) {
+                    sendBadRequest(exchange);
+                    return;
+                }
+
+                Subtask subtask = gson.fromJson(requestBody, Subtask.class);
+
+                Epic epic = taskManager.getEpic(subtask.getEpicId());
+                if (epic == null) {
+                    sendNotFound(exchange);
+                    return;
+                }
+
+                if (subtask.getId() != 0) {
+                    try {
+                        taskManager.updateSubtask(subtask);
+                        sendJson(exchange, subtask, 200);
+                    } catch (Exception e) {
+                        sendIntersection(exchange);
+                    }
+                } else {
+                    taskManager.addSubtask(subtask);
+                    exchange.getResponseHeaders().set("Location", "/subtasks/" + subtask.getId());
+                    sendJson(exchange, subtask, 201);
+                }
+            } else {
+                sendNotFound(exchange);
+            }
+        } catch (NotFoundException e) {
+            sendNotFound(exchange);
+        } catch (Exception e) {
+            sendInternalError(exchange);
+        }
+    }
+
+    @Override
+    protected void handleDelete(HttpExchange exchange, String path) throws IOException {
+        try {
+            if (!path.startsWith("/subtasks/")) {
+                sendNotFound(exchange);
+                return;
+            }
+
+            String subtaskIdStr = path.substring("/subtasks/".length());
+            if (subtaskIdStr.isEmpty()) {
+                sendBadRequest(exchange);
+                return;
+            }
+
+            int taskId = Integer.parseInt(subtaskIdStr);
+            taskManager.deleteSubtaskById(taskId);
+            sendJson(exchange, null, 200);
+        } catch (NumberFormatException e) {
+            sendBadRequest(exchange);
+        } catch (NotFoundException e) {
+            sendNotFound(exchange);
+        } catch (Exception e) {
+            sendInternalError(exchange);
+        }
+    }
+}

--- a/src/tracker/server/handlers/TasksHandler.java
+++ b/src/tracker/server/handlers/TasksHandler.java
@@ -1,0 +1,103 @@
+package tracker.server.handlers;
+
+import com.sun.net.httpserver.HttpExchange;
+import tracker.exceptions.NotFoundException;
+import tracker.interfaces.TaskManager;
+import tracker.model.Task;
+
+import java.io.IOException;
+
+public class TasksHandler extends BaseHttpHandler {
+
+    public TasksHandler(TaskManager taskManager) {
+        super(taskManager);
+    }
+
+    @Override
+    protected void handleGet(HttpExchange exchange, String path) throws IOException {
+        try {
+            if (path.equals("/tasks")) {
+                sendJson(exchange, taskManager.getTasks(), 200);
+            } else if (path.startsWith("/tasks/")) {
+                String taskIdStr = path.substring("/tasks/".length());
+
+                if (taskIdStr.isEmpty()) {
+                    sendBadRequest(exchange);
+                    return;
+                }
+
+                int taskId = Integer.parseInt(taskIdStr);
+                sendJson(exchange, taskManager.getTask(taskId), 200);
+            } else {
+                sendNotFound(exchange);
+            }
+        } catch (NotFoundException e) {
+            sendNotFound(exchange);
+        } catch (NumberFormatException e) {
+            sendBadRequest(exchange);
+        } catch (Exception e) {
+            sendInternalError(exchange);
+        }
+    }
+
+    @Override
+    protected void handlePost(HttpExchange exchange, String path) throws IOException {
+        try {
+            if (path.equals("/tasks")) {
+                String requestBody = readText(exchange);
+                Task task = gson.fromJson(requestBody, Task.class);
+
+                if (task == null) {
+                    sendBadRequest(exchange);
+                    return;
+                }
+
+                if (task.getId() != 0) {
+                    try {
+                        taskManager.updateTask(task);
+                        sendJson(exchange, task, 200);
+                    } catch (Exception e) {
+                        sendIntersection(exchange);
+                    }
+                } else {
+                    taskManager.addTask(task);
+                    exchange.getResponseHeaders().set("Location", "/tasks/" + task.getId());
+                    sendJson(exchange, task, 201);
+                }
+            } else {
+                sendNotFound(exchange);
+            }
+        } catch (NotFoundException e) {
+            sendNotFound(exchange);
+        } catch (Exception e) {
+            sendInternalError(exchange);
+        }
+    }
+
+
+    @Override
+    protected void handleDelete(HttpExchange exchange, String path) throws IOException {
+        try {
+            if (!path.startsWith("/tasks/")) {
+                sendNotFound(exchange);
+                return;
+            }
+
+            String taskIdStr = path.substring("/tasks/".length());
+            if (taskIdStr.isEmpty()) {
+                sendBadRequest(exchange);
+                return;
+            }
+
+            int taskId = Integer.parseInt(taskIdStr);
+            taskManager.deleteTaskById(taskId);
+            sendJson(exchange, null, 200);
+        } catch (NumberFormatException e) {
+            sendBadRequest(exchange);
+        } catch (NotFoundException e) {
+            sendNotFound(exchange);
+        } catch (Exception e) {
+            sendInternalError(exchange);
+        }
+    }
+}

--- a/src/tracker/server/handlers/adapters/DurationAdapter.java
+++ b/src/tracker/server/handlers/adapters/DurationAdapter.java
@@ -1,0 +1,31 @@
+package tracker.server.handlers.adapters;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.time.Duration;
+
+public class DurationAdapter extends TypeAdapter<Duration> {
+
+    @Override
+    public void write(JsonWriter out, Duration duration) throws IOException {
+        if (duration == null) {
+            out.nullValue();
+        } else {
+            out.value(duration.toString());
+        }
+    }
+
+    @Override
+    public Duration read(JsonReader jsonReader) throws IOException {
+        if (jsonReader.peek() == JsonToken.NULL) {
+            jsonReader.nextNull();
+            return null;
+        } else {
+            return Duration.parse(jsonReader.nextString());
+        }
+    }
+}

--- a/src/tracker/server/handlers/adapters/LocalDateTimeAdapter.java
+++ b/src/tracker/server/handlers/adapters/LocalDateTimeAdapter.java
@@ -1,0 +1,32 @@
+package tracker.server.handlers.adapters;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+public class LocalDateTimeAdapter extends TypeAdapter<LocalDateTime> {
+
+    @Override
+    public void write(final JsonWriter jsonWriter, final LocalDateTime localDateTime) throws IOException {
+        if (localDateTime == null) {
+            jsonWriter.nullValue();
+        } else {
+            jsonWriter.value(localDateTime.toString());
+        }
+    }
+
+    @Override
+    public LocalDateTime read(final JsonReader jsonReader) throws IOException {
+        if (jsonReader.peek() == JsonToken.NULL) {
+            jsonReader.nextNull();
+            return null;
+        } else {
+            return LocalDateTime.parse(jsonReader.nextString());
+        }
+    }
+}
+

--- a/test/tracker/interfaces/TaskManagerTest.java
+++ b/test/tracker/interfaces/TaskManagerTest.java
@@ -98,7 +98,7 @@ public abstract class TaskManagerTest<T extends TaskManager> {
     public void shouldDeleteTaskByID() {
         tm.addTask(task);
         tm.deleteTaskById(task.getId());
-        assertNull(tm.getTask(task.getId()), "задача не удалена");
+        assertEquals(0, tm.getTasks().size(), "Значения не совпадают");
     }
 
 
@@ -129,7 +129,7 @@ public abstract class TaskManagerTest<T extends TaskManager> {
     void shouldDeleteEpicById() {
         tm.addEpic(epic);
         tm.deleteEpicById(epic.getId());
-        assertNull(tm.getEpic(epic.getId()), "эпик не удалён");
+        assertEquals(0, tm.getEpics().size(), "Количество эпиков не совпадает");
     }
 
     @Test
@@ -145,7 +145,7 @@ public abstract class TaskManagerTest<T extends TaskManager> {
         tm.addEpic(epic);
         tm.addSubtask(subtask);
         tm.deleteEpicById(epic.getId());
-        assertNull(tm.getEpic(epic.getId()), "эпик не удалён");
+        assertEquals(0, tm.getEpics().size(), "Количество эпиков не совпадает");
         assertEquals(0, tm.getSubtasks().size(), "Подзадача не удалена");
     }
 
@@ -190,7 +190,7 @@ public abstract class TaskManagerTest<T extends TaskManager> {
         tm.addEpic(epic);
         tm.addSubtask(subtask);
         tm.deleteSubtaskById(subtask.getId());
-        assertNull(tm.getSubtask(subtask.getId()), "подзадача не удалена");
+        assertEquals(0, tm.getSubtasks().size(), "Количество подзадач не совпадает");
     }
 
     @Test

--- a/test/tracker/server/HttpTaskServerTest.java
+++ b/test/tracker/server/HttpTaskServerTest.java
@@ -1,0 +1,114 @@
+package tracker.server;
+
+import com.google.gson.Gson;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import tracker.constants.Status;
+import tracker.interfaces.TaskManager;
+import tracker.managers.Managers;
+import tracker.model.Epic;
+import tracker.model.Subtask;
+import tracker.model.Task;
+import tracker.server.handlers.BaseHttpHandler;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+public abstract class HttpTaskServerTest {
+
+    protected final int PORT = 8080;
+    protected TaskManager taskManager;
+    protected HttpTaskServer server;
+    protected Gson gson;
+
+    protected Task task;
+    protected Task anotherTask;
+    protected Epic epic;
+    protected Epic anotherEpic;
+    protected Subtask subtask;
+    protected Subtask anotherSubtask;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        taskManager = Managers.getDefault();
+        server = new HttpTaskServer(taskManager);
+        gson = BaseHttpHandler.createGson();
+
+        task = new Task(1, "прогулка", "ходьба в парке", Status.IN_PROGRESS,
+                Duration.ofMinutes(60), LocalDateTime.of(2025, 3, 14, 10, 0));
+        anotherTask = new Task(2, "другая задача", "другое описание", Status.IN_PROGRESS,
+                Duration.ofMinutes(60), LocalDateTime.of(2025, 3, 15, 10, 0));
+        epic = new Epic(3, "переезд", "смена места жительства");
+        subtask = new Subtask(3, 4, "сборка", "упаковать вещи", Status.IN_PROGRESS,
+                Duration.ofMinutes(90), LocalDateTime.now());
+        anotherSubtask = new Subtask(3, 5, "разбор", "разобрать вещи", Status.DONE,
+                Duration.ofMinutes(45), LocalDateTime.now().plusHours(3));
+        anotherEpic = new Epic(6, "название эпика", "описание эпика");
+
+
+        taskManager.addTask(task);
+        taskManager.addTask(anotherTask);
+        taskManager.addEpic(epic);
+        taskManager.addSubtask(subtask);
+        taskManager.addSubtask(anotherSubtask);
+        taskManager.addEpic(anotherEpic);
+
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop();
+        taskManager.clearAll();
+    }
+
+    protected HttpResponse<String> sendRequest(String url, String method, String body)
+            throws IOException, InterruptedException {
+
+        if (url == null) {
+            throw new IllegalArgumentException("URL не может быть null");
+        }
+        if (method == null) {
+            throw new IllegalArgumentException("Метод не может быть null");
+        }
+
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .method(method,
+                            body != null ? HttpRequest.BodyPublishers.ofString(body)
+                                    : HttpRequest.BodyPublishers.noBody())
+                    .build();
+            return client.send(request, HttpResponse.BodyHandlers.ofString());
+        }
+    }
+
+    protected String getBaseUrl() {
+        return "http://localhost:" + PORT;
+    }
+
+    protected String getTasksUrl() {
+        return getBaseUrl() + "/tasks";
+    }
+
+    protected String getEpicsUrl() {
+        return getBaseUrl() + "/epics";
+    }
+
+    protected String getSubtasksUrl() {
+        return getBaseUrl() + "/subtasks";
+    }
+
+    protected String getHistoryUrl() {
+        return getBaseUrl() + "/history";
+    }
+
+    protected String getPrioritizedUrl() {
+        return getBaseUrl() + "/prioritized";
+    }
+}

--- a/test/tracker/server/handlers/EpicsHandlerTest.java
+++ b/test/tracker/server/handlers/EpicsHandlerTest.java
@@ -1,0 +1,190 @@
+package tracker.server.handlers;
+
+import com.google.gson.reflect.TypeToken;
+import org.junit.jupiter.api.Test;
+import tracker.exceptions.NotFoundException;
+import tracker.model.Epic;
+import tracker.model.Subtask;
+import tracker.server.HttpTaskServerTest;
+
+import java.io.IOException;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EpicsHandlerTest extends HttpTaskServerTest {
+
+    @Test
+    void shouldGetAllEpicsEmpty() throws IOException, InterruptedException {
+        taskManager.deleteEpics();
+
+        HttpResponse<String> response = sendRequest(getEpicsUrl(), "GET", null);
+        String responseBody = response.body();
+        List<Epic> epics = gson.fromJson(responseBody, new TypeToken<List<Epic>>() {
+        }.getType());
+
+        assertEquals(200, response.statusCode(), "Неверный HTTP-статус");
+        assertEquals(0, epics.size(), "Список эпиков должен быть пустым");
+        assertTrue(epics.isEmpty(), "Список эпиков должен быть пустым");
+    }
+
+    @Test
+    void shouldGetAllEpics() throws IOException, InterruptedException {
+        HttpResponse<String> response = sendRequest(getEpicsUrl(), "GET", null);
+        String responseBody = response.body();
+        List<Epic> epics = gson.fromJson(responseBody, new TypeToken<List<Epic>>() {
+        }.getType());
+
+        assertEquals(200, response.statusCode(), "Неверный HTTP-статус");
+        assertEquals(2, epics.size(), "Неверное количество эпиков");
+        assertTrue(epics.contains(epic), "Эпик отсутствует в списке");
+        assertTrue(epics.contains(anotherEpic), "Другой эпик отсутствует в списке");
+
+        epics.forEach(e -> {
+            assertNotNull(e.getTitle(), "Имя эпика не должно быть пустым");
+            assertNotNull(e.getDescription(), "Описание эпика не должно быть пустым");
+        });
+    }
+
+
+    @Test
+    void shouldGetSingleEpic() throws IOException, InterruptedException {
+        String url = getEpicsUrl() + "/" + epic.getId();
+        HttpResponse<String> response = sendRequest(url, "GET", null);
+        String responseBody = response.body();
+        Epic responseEpic = gson.fromJson(responseBody, Epic.class);
+
+        assertEquals(200, response.statusCode(), "Неверный HTTP-статус");
+
+        assertNotNull(responseEpic, "Эпик не должен быть null");
+        assertEquals(epic.getId(), responseEpic.getId(), "ID эпика не совпадает");
+        assertEquals(epic.getTitle(), responseEpic.getTitle(), "Название эпика не совпадает");
+        assertEquals(epic.getDescription(), responseEpic.getDescription(), "Описание эпика не совпадает");
+        assertEquals(epic.getStatus(), responseEpic.getStatus(), "Статус эпика не совпадает");
+        assertEquals(epic.getStartTime(), responseEpic.getStartTime(), "Время начала эпика не совпадает");
+        assertEquals(epic.getDuration(), responseEpic.getDuration(), "Длительность эпика не совпадает");
+    }
+
+    @Test
+    void shouldGetEpicSubtasks() throws IOException, InterruptedException {
+        HttpResponse<String> epicResponse = sendRequest(getEpicsUrl(), "GET", null);
+        List<Epic> epics = gson.fromJson(epicResponse.body(), new TypeToken<List<Epic>>() {
+        }.getType());
+        Epic existingEpic = epics.getFirst();
+
+        String epicSubtasksUrl = getEpicsUrl() + "/" + existingEpic.getId() + "/subtasks";
+        HttpResponse<String> response = sendRequest(epicSubtasksUrl, "GET", null);
+        String responseBody = response.body();
+        List<Subtask> subtasks = gson.fromJson(responseBody, new TypeToken<List<Subtask>>() {
+        }.getType());
+
+        assertEquals(200, response.statusCode(), "Неверный HTTP-статус");
+        assertFalse(subtasks.isEmpty(), "Список подзадач должен содержать элементы");
+
+        subtasks.forEach(subtask -> {
+            assertTrue(subtask.getId() > 0, "ID подзадачи должен быть больше нуля");
+            assertNotNull(subtask.getTitle(), "Название подзадачи не должно быть пустым");
+            assertNotNull(subtask.getStatus(), "Статус подзадачи не должен быть пустым");
+            assertTrue(subtask.getEpicId() > 0, "ID связанного эпика должен быть больше нуля");
+            assertEquals(existingEpic.getId(), subtask.getEpicId(), "ID связанного эпика должен совпадать");
+        });
+    }
+
+    @Test
+    void shouldCreateEpic() throws IOException, InterruptedException {
+        Epic newEpic = new Epic("новый эпик", "описание нового эпика");
+
+        String requestBody = gson.toJson(newEpic);
+        HttpResponse<String> response = sendRequest(getEpicsUrl(), "POST", requestBody);
+        String responseBody = response.body();
+
+        assertEquals(201, response.statusCode(), "Неверный HTTP-статус");
+
+        Epic createdEpic = gson.fromJson(responseBody, Epic.class);
+
+        assertNotNull(createdEpic, "Созданный эпик не должен быть null");
+        assertTrue(createdEpic.getId() > 0, "ID созданного эпика должен быть больше 0");
+        assertEquals(newEpic.getTitle(), createdEpic.getTitle(), "Название эпика не совпадает");
+        assertEquals(newEpic.getDescription(), createdEpic.getDescription(), "Описание эпика не совпадает");
+        assertNotEquals(newEpic.getStatus(), createdEpic.getStatus(), "Статус нового эпика 'NEW'");
+        assertEquals(newEpic.getStartTime(), createdEpic.getStartTime(), "Время начала эпика не совпадает");
+        assertEquals(newEpic.getDuration(), createdEpic.getDuration(), "Длительность эпика не совпадает");
+    }
+
+    @Test
+    void shouldDeleteEpic() throws IOException, InterruptedException {
+        String url = getEpicsUrl() + "/" + epic.getId();
+        HttpResponse<String> response = sendRequest(url, "DELETE", null);
+
+        assertEquals(200, response.statusCode(), "Неверный HTTP-статус");
+
+        try {
+            taskManager.getEpic(epic.getId());
+            fail("Должна быть выброшена NotFoundException");
+        } catch (NotFoundException e) {
+            // Ожидаемое поведение
+        }
+
+        HttpResponse<String> responseAfterDelete = sendRequest(url, "GET", null);
+        assertEquals(404, responseAfterDelete.statusCode(),
+                "При получении удаленного эпика должен быть статус 404");
+    }
+
+    // Проверка исключений
+
+    @Test
+    void shouldDeleteNonExistingEpic() throws IOException, InterruptedException {
+        String url = getEpicsUrl() + "/999";
+        HttpResponse<String> response = sendRequest(url, "DELETE", null);
+
+        assertEquals(404, response.statusCode(),
+                "При попытке удалить несуществующий эпик должен быть статус 404");
+
+        String responseBody = response.body();
+        assertTrue(responseBody.contains("\"error\": \"Ресурс не найден\""),
+                "Ожидалось сообщение об ошибке 'Ресурс не найден'");
+
+        HttpResponse<String> responseAfterDelete = sendRequest(url, "GET", null);
+
+        assertEquals(404, responseAfterDelete.statusCode(),
+                "При получении несуществующего эпика должен быть статус 404");
+    }
+
+    @Test
+    void shouldGetInvalidEpicId() throws IOException, InterruptedException {
+        String url = getEpicsUrl() + "/id";
+        HttpResponse<String> response = sendRequest(url, "GET", null);
+
+        assertEquals(400, response.statusCode(),
+                "При некорректном ID эпика должен быть статус 400");
+
+        String responseBody = response.body();
+        assertTrue(responseBody.contains("\"error\": \"Некорректный запрос\""),
+                "Ожидалось сообщение об ошибке 'Некорректный запрос'");
+
+        HttpResponse<String> responseAfter = sendRequest(url, "GET", null);
+
+        assertEquals(400, responseAfter.statusCode(),
+                "При повторном запросе с некорректным ID должен быть статус 400");
+    }
+
+    @Test
+    void shouldPostInvalidEpicWithEmptyBody() throws IOException, InterruptedException {
+        String url = getEpicsUrl();
+        HttpResponse<String> response = sendRequest(url, "POST", null);
+
+        assertEquals(400, response.statusCode(),
+                "При некорректном эпике должен быть статус 400");
+
+        String responseBody = response.body();
+        assertTrue(responseBody.contains("\"error\": \"Некорректный запрос\""),
+                "Ожидалось сообщение об ошибке 'Некорректный запрос'");
+
+        HttpResponse<String> responseAfter = sendRequest(url, "POST", null);
+
+        assertEquals(400, responseAfter.statusCode(),
+                "При повторном запросе с некорректным эпиком должен быть статус 400");
+    }
+
+}

--- a/test/tracker/server/handlers/HistoryHandlerTest.java
+++ b/test/tracker/server/handlers/HistoryHandlerTest.java
@@ -1,0 +1,64 @@
+package tracker.server.handlers;
+
+import com.google.gson.reflect.TypeToken;
+import org.junit.jupiter.api.Test;
+import tracker.model.Task;
+import tracker.server.HttpTaskServerTest;
+
+import java.io.IOException;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HistoryHandlerTest extends HttpTaskServerTest {
+
+
+    @Test
+    void shouldGetEmptyHistory() throws IOException, InterruptedException {
+
+        HttpResponse<String> response = sendRequest(getHistoryUrl(), "GET", null);
+        String responseBody = response.body();
+        List<Task> history = gson.fromJson(responseBody, new TypeToken<List<Task>>() {
+        }.getType());
+
+        assertEquals(200, response.statusCode(), "Неверный HTTP-статус");
+        assertTrue(history.isEmpty(), "История не должна содержать элементы");
+    }
+
+    @Test
+    void shouldGetHistory() throws IOException, InterruptedException {
+
+        taskManager.getTask(task.getId());
+        taskManager.getEpic(epic.getId());
+        taskManager.getSubtask(subtask.getId());
+
+        HttpResponse<String> response = sendRequest(getHistoryUrl(), "GET", null);
+        String responseBody = response.body();
+        List<Task> history = gson.fromJson(responseBody, new TypeToken<List<Task>>() {
+        }.getType());
+
+        assertEquals(200, response.statusCode(), "Неверный HTTP-статус");
+        assertFalse(history.isEmpty(), "История должна содержать элементы");
+
+        history.forEach(task -> {
+            assertNotNull(task.getTitle(), "Имя не должно быть пустым");
+            assertNotNull(task.getDescription(), "Описание не должно быть пустым");
+        });
+    }
+
+    @Test
+    void shouldGetInvalidRequestHistory() throws IOException, InterruptedException {
+        String url = getBaseUrl() + "/invalid";
+        HttpResponse<String> response = sendRequest(url, "GET", null);
+
+        assertEquals(404, response.statusCode(),
+                "При несуществующем пути запроса должен быть статус 400");
+
+        HttpResponse<String> responseAfter = sendRequest(url, "GET", null);
+
+        assertEquals(404, responseAfter.statusCode(),
+                "При повторном запросе с несуществующим путём должен быть статус 404");
+    }
+
+}

--- a/test/tracker/server/handlers/PrioritizedHandlerTest.java
+++ b/test/tracker/server/handlers/PrioritizedHandlerTest.java
@@ -1,0 +1,59 @@
+package tracker.server.handlers;
+
+import com.google.gson.reflect.TypeToken;
+import org.junit.jupiter.api.Test;
+import tracker.model.Task;
+import tracker.server.HttpTaskServerTest;
+
+import java.io.IOException;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PrioritizedHandlerTest extends HttpTaskServerTest {
+
+    @Test
+    void shouldGetEmptyPrioritizedTasks() throws IOException, InterruptedException {
+
+        taskManager.clearAll();
+
+        HttpResponse<String> response = sendRequest(getPrioritizedUrl(), "GET", null);
+        String responseBody = response.body();
+        List<Task> prioritized = gson.fromJson(responseBody, new TypeToken<List<Task>>() {
+        }.getType());
+
+        assertEquals(200, response.statusCode(), "Неверный HTTP-статус");
+        assertTrue(prioritized.isEmpty(), "Список не должен содержать элементы");
+    }
+
+    @Test
+    void shouldGetPrioritizedTasks() throws IOException, InterruptedException {
+        HttpResponse<String> response = sendRequest(getPrioritizedUrl(), "GET", null);
+        String responseBody = response.body();
+        List<Task> prioritized = gson.fromJson(responseBody, new TypeToken<List<Task>>() {
+        }.getType());
+
+        assertEquals(200, response.statusCode(), "Неверный HTTP-статус");
+        assertFalse(prioritized.isEmpty(), "Список должен содержать элементы");
+
+        prioritized.forEach(task -> {
+            assertNotNull(task.getTitle(), "Имя не должно быть пустым");
+            assertNotNull(task.getDescription(), "Описание не должно быть пустым");
+        });
+    }
+
+    @Test
+    void shouldGetInvalidRequestPrioritized() throws IOException, InterruptedException {
+        String url = getBaseUrl() + "/invalid";
+        HttpResponse<String> response = sendRequest(url, "GET", null);
+
+        assertEquals(404, response.statusCode(),
+                "При несуществующем пути запроса должен быть статус 400");
+
+        HttpResponse<String> responseAfter = sendRequest(url, "GET", null);
+
+        assertEquals(404, responseAfter.statusCode(),
+                "При повторном запросе с несуществующим путём должен быть статус 404");
+    }
+}

--- a/test/tracker/server/handlers/SubtasksHandlerTest.java
+++ b/test/tracker/server/handlers/SubtasksHandlerTest.java
@@ -1,0 +1,221 @@
+package tracker.server.handlers;
+
+import com.google.gson.reflect.TypeToken;
+import org.junit.jupiter.api.Test;
+import tracker.constants.Status;
+import tracker.exceptions.NotFoundException;
+import tracker.model.Subtask;
+import tracker.server.HttpTaskServerTest;
+
+import java.io.IOException;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SubtasksHandlerTest extends HttpTaskServerTest {
+
+    @Test
+    void shouldGetAllSubtasksEmpty() throws IOException, InterruptedException {
+        taskManager.deleteEpics();
+        taskManager.deleteSubtasks();
+
+        HttpResponse<String> response = sendRequest(getSubtasksUrl(), "GET", null);
+        String responseBody = response.body();
+        List<Subtask> subtasks = gson.fromJson(responseBody, new TypeToken<List<Subtask>>() {
+        }.getType());
+
+        assertEquals(200, response.statusCode(), "Неверный HTTP-статус");
+        assertEquals(0, subtasks.size(), "Список подзадач должен быть пустым");
+        assertTrue(subtasks.isEmpty(), "Список подзадач должен быть пустым");
+    }
+
+    @Test
+    void shouldGetAllSubtasks() throws IOException, InterruptedException {
+        HttpResponse<String> response = sendRequest(getSubtasksUrl(), "GET", null);
+        String responseBody = response.body();
+        List<Subtask> subtasks = gson.fromJson(responseBody, new TypeToken<List<Subtask>>() {
+        }.getType());
+
+        assertEquals(200, response.statusCode(), "Неверный HTTP-статус");
+        assertEquals(2, subtasks.size(), "Неверное количество подзадач");
+        assertTrue(subtasks.contains(subtask), "Подзадача отсутствует в списке");
+        assertTrue(subtasks.contains(anotherSubtask), "Другая подзадача отсутствует в списке");
+
+        subtasks.forEach(s -> {
+            assertNotNull(s.getTitle(), "Имя подзадачи не должно быть пустым");
+            assertNotNull(s.getDescription(), "Описание подзадачи не должно быть пустым");
+            assertNotNull(s.getStartTime(), "Дата начала не должна быть пустой");
+        });
+    }
+
+    @Test
+    void shouldGetSingleSubtask() throws IOException, InterruptedException {
+        String url = getSubtasksUrl() + "/" + subtask.getId();
+        HttpResponse<String> response = sendRequest(url, "GET", null);
+        String responseBody = response.body();
+        Subtask responseSubtask = gson.fromJson(responseBody, Subtask.class);
+
+        assertEquals(200, response.statusCode(), "Неверный HTTP-статус");
+
+        assertNotNull(responseSubtask, "Подзадача не должна быть null");
+        assertEquals(subtask.getId(), responseSubtask.getId(), "ID подзадачи не совпадает");
+        assertEquals(subtask.getTitle(), responseSubtask.getTitle(), "Название подзадачи не совпадает");
+        assertEquals(subtask.getDescription(), responseSubtask.getDescription(),
+                "Описание подзадачи не совпадает");
+        assertEquals(subtask.getStatus(), responseSubtask.getStatus(), "Статус подзадачи не совпадает");
+        assertEquals(subtask.getStartTime(), responseSubtask.getStartTime(),
+                "Время начала подзадачи не совпадает");
+        assertEquals(subtask.getDuration(), responseSubtask.getDuration(),
+                "Длительность подзадачи не совпадает");
+    }
+
+    @Test
+    void shouldCreateSubtaskForEpic() throws IOException, InterruptedException {
+
+        Subtask newSubtask = new Subtask(
+                anotherEpic.getId(), "новая подзадача", "описание новой подзадачи",
+                Status.IN_PROGRESS,
+                Duration.ofMinutes(60),
+                LocalDateTime.of(2025, 3, 20, 10, 0));
+
+        String subtaskRequestBody = gson.toJson(newSubtask);
+        HttpResponse<String> subtaskResponse = sendRequest(getSubtasksUrl(), "POST", subtaskRequestBody);
+        Subtask createdSubtask = gson.fromJson(subtaskResponse.body(), Subtask.class);
+
+        assertEquals(201, subtaskResponse.statusCode(), "Неверный HTTP-статус для создания подзадачи");
+        assertNotNull(createdSubtask, "Созданная подзадача не должна быть null");
+        assertTrue(createdSubtask.getId() > 0, "ID созданной подзадачи должен быть больше 0");
+        assertEquals(newSubtask.getTitle(), createdSubtask.getTitle(), "Название подзадачи не совпадает");
+        assertEquals(newSubtask.getDescription(), createdSubtask.getDescription(),
+                "Описание подзадачи не совпадает");
+        assertEquals(anotherEpic.getId(), createdSubtask.getEpicId(), "ID связанного эпика не совпадает");
+    }
+
+    @Test
+    void shouldUpdateSubtask() throws IOException, InterruptedException {
+
+        Subtask updatedSubtask = new Subtask(epic.getId(), epic.getSubtasksIds().getFirst(),
+                "обновленная подзадача",
+                "обновленное описание",
+                Status.DONE,
+                Duration.ofMinutes(90),
+                LocalDateTime.of(2025, 3, 14, 12, 0));
+
+        String updatedSubtaskRequestBody = gson.toJson(updatedSubtask);
+        HttpResponse<String> updateResponse = sendRequest(getSubtasksUrl(), "POST", updatedSubtaskRequestBody);
+        Subtask updatedCreatedSubtask = gson.fromJson(updateResponse.body(), Subtask.class);
+
+        assertEquals(200, updateResponse.statusCode(),
+                "Неверный HTTP-статус для обновления подзадачи");
+        assertNotNull(updatedCreatedSubtask, "Обновленная подзадача не должна быть null");
+        assertEquals(updatedSubtask.getTitle(), updatedCreatedSubtask.getTitle(),
+                "Название подзадачи не совпадает");
+        assertEquals(updatedSubtask.getDescription(), updatedCreatedSubtask.getDescription(),
+                "Описание подзадачи не совпадает");
+        assertEquals(updatedSubtask.getStatus(), updatedCreatedSubtask.getStatus(),
+                "Статус подзадачи не совпадает");
+        assertEquals(updatedSubtask.getEpicId(), updatedCreatedSubtask.getEpicId(),
+                "ID связанного эпика не совпадает");
+    }
+
+    @Test
+    void shouldDeleteSubtask() throws IOException, InterruptedException {
+        String url = getSubtasksUrl() + "/" + subtask.getId();
+        HttpResponse<String> response = sendRequest(url, "DELETE", null);
+
+        assertEquals(200, response.statusCode(), "Неверный HTTP-статус");
+
+        try {
+            taskManager.getSubtask(subtask.getId());
+            fail("Должна быть выброшена NotFoundException");
+        } catch (NotFoundException e) {
+            // Ожидаемое поведение
+        }
+
+        HttpResponse<String> responseAfterDelete = sendRequest(url, "GET", null);
+        assertEquals(404, responseAfterDelete.statusCode(),
+                "При получении удаленной подзадачи должен быть статус 404");
+    }
+
+    // Проверка исключений
+
+    @Test
+    void shouldDeleteNonExistingSubtask() throws IOException, InterruptedException {
+        String url = getSubtasksUrl() + "/999";
+        HttpResponse<String> response = sendRequest(url, "DELETE", null);
+
+        assertEquals(404, response.statusCode(),
+                "При попытке удалить несуществующую подзадачу должен быть статус 404");
+
+        String responseBody = response.body();
+        assertTrue(responseBody.contains("\"error\": \"Ресурс не найден\""),
+                "Ожидалось сообщение об ошибке 'Ресурс не найден'");
+
+        HttpResponse<String> responseAfterDelete = sendRequest(url, "GET", null);
+
+        assertEquals(404, responseAfterDelete.statusCode(),
+                "При получении несуществующей подзадачи должен быть статус 404");
+    }
+
+    @Test
+    void shouldGetInvalidSubtaskId() throws IOException, InterruptedException {
+        String url = getSubtasksUrl() + "/id";
+        HttpResponse<String> response = sendRequest(url, "GET", null);
+
+        assertEquals(400, response.statusCode(),
+                "При некорректном ID подзадачи должен быть статус 400");
+
+        String responseBody = response.body();
+        assertTrue(responseBody.contains("\"error\": \"Некорректный запрос\""),
+                "Ожидалось сообщение об ошибке 'Некорректный запрос'");
+
+        HttpResponse<String> responseAfter = sendRequest(url, "GET", null);
+
+        assertEquals(400, responseAfter.statusCode(),
+                "При повторном запросе с некорректным ID должен быть статус 400");
+    }
+
+    @Test
+    void shouldPostInvalidSubtaskWithEmptyBody() throws IOException, InterruptedException {
+        String url = getSubtasksUrl();
+        HttpResponse<String> response = sendRequest(url, "POST", null);
+
+        assertEquals(400, response.statusCode(),
+                "При некорректной подзадаче должен быть статус 400");
+
+        String responseBody = response.body();
+        assertTrue(responseBody.contains("\"error\": \"Некорректный запрос\""),
+                "Ожидалось сообщение об ошибке 'Некорректный запрос'");
+
+        HttpResponse<String> responseAfter = sendRequest(url, "POST", null);
+
+        assertEquals(400, responseAfter.statusCode(),
+                "При повторном запросе с некорректной подзадачей должен быть статус 400");
+    }
+
+    @Test
+    void shouldUpdateSubtaskWithIntersection() throws IOException, InterruptedException {
+        // Создаем вторую подзадачу с пересекающимся временем
+        Subtask updateSubtask = new Subtask(epic.getId(), epic.getSubtasksIds().getFirst(),
+                "обновленная подзадача",
+                "обновленное описание",
+                Status.DONE,
+                Duration.ofMinutes(90),
+                LocalDateTime.now().plusMinutes(30)
+        );
+
+        String requestBody = gson.toJson(updateSubtask);
+
+        HttpResponse<String> response = sendRequest(getTasksUrl(), "POST", requestBody);
+
+        assertEquals(409, response.statusCode(), "Должен быть статус 409 при пересечении задач");
+
+        String responseBody = response.body();
+        assertTrue(responseBody.contains("\"error\": \"Пересечение по времени\""),
+                "Ожидалось сообщение об ошибке 'Пересечение по времени'");
+    }
+
+}

--- a/test/tracker/server/handlers/TasksHandlerTest.java
+++ b/test/tracker/server/handlers/TasksHandlerTest.java
@@ -1,0 +1,212 @@
+package tracker.server.handlers;
+
+import com.google.gson.reflect.TypeToken;
+import org.junit.jupiter.api.Test;
+import tracker.constants.Status;
+import tracker.exceptions.NotFoundException;
+import tracker.model.Task;
+import tracker.server.HttpTaskServerTest;
+
+import java.io.IOException;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TasksHandlerTest extends HttpTaskServerTest {
+
+    @Test
+    void shouldGetAllTasksEmpty() throws IOException, InterruptedException {
+        taskManager.deleteTasks();
+
+        HttpResponse<String> response = sendRequest(getTasksUrl(), "GET", null);
+        String responseBody = response.body();
+        List<Task> tasks = gson.fromJson(responseBody, new TypeToken<List<Task>>() {
+        }.getType());
+
+        assertEquals(200, response.statusCode(), "Неверный HTTP-статус");
+        assertEquals(0, tasks.size(), "Список задач должен быть пустым");
+        assertTrue(tasks.isEmpty(), "Список задач должен быть пустым");
+    }
+
+
+    @Test
+    void shouldGetAllTasks() throws IOException, InterruptedException {
+        HttpResponse<String> response = sendRequest(getTasksUrl(), "GET", null);
+        String responseBody = response.body();
+        List<Task> tasks = gson.fromJson(responseBody, new TypeToken<List<Task>>() {
+        }.getType());
+
+        assertEquals(200, response.statusCode(), "Неверный HTTP-статус");
+        assertEquals(2, tasks.size(), "Неверное количество задач");
+        assertTrue(tasks.contains(task), "Задача отсутствует в списке");
+        assertTrue(tasks.contains(anotherTask), "Другая задача отсутствует в списке");
+
+        tasks.forEach(t -> {
+            assertNotNull(t.getTitle(), "Имя задачи не должно быть пустым");
+            assertNotNull(t.getDescription(), "Описание задачи не должно быть пустым");
+            assertNotNull(t.getStartTime(), "Дата начала не должна быть пустой");
+        });
+    }
+
+    @Test
+    void shouldGetSingleTask() throws IOException, InterruptedException {
+        String url = getTasksUrl() + "/" + task.getId();
+        HttpResponse<String> response = sendRequest(url, "GET", null);
+        String responseBody = response.body();
+        Task responseTask = gson.fromJson(responseBody, Task.class);
+
+        assertEquals(200, response.statusCode(), "Неверный HTTP-статус");
+
+        assertNotNull(responseTask, "Задача не должна быть null");
+        assertEquals(task.getId(), responseTask.getId(), "ID задачи не совпадает");
+        assertEquals(task.getTitle(), responseTask.getTitle(), "Название задачи не совпадает");
+        assertEquals(task.getDescription(), responseTask.getDescription(), "Описание задачи не совпадает");
+        assertEquals(task.getStatus(), responseTask.getStatus(), "Статус задачи не совпадает");
+        assertEquals(task.getStartTime(), responseTask.getStartTime(), "Время начала задачи не совпадает");
+        assertEquals(task.getDuration(), responseTask.getDuration(), "Длительность задачи не совпадает");
+    }
+
+    @Test
+    void shouldCreateTask() throws IOException, InterruptedException {
+        Task newTask = new Task("новая задача", "описание новой задачи", Status.IN_PROGRESS,
+                Duration.ofMinutes(30), LocalDateTime.of(2025, 3, 16, 10, 0));
+
+        String requestBody = gson.toJson(newTask);
+        HttpResponse<String> response = sendRequest(getTasksUrl(), "POST", requestBody);
+        String responseBody = response.body();
+
+        assertEquals(201, response.statusCode(), "Неверный HTTP-статус");
+
+        Task createdTask = gson.fromJson(responseBody, Task.class);
+
+        assertNotNull(createdTask, "Созданная задача не должна быть null");
+        assertTrue(createdTask.getId() > 0, "ID созданной задачи должен быть больше 0");
+        assertEquals(newTask.getTitle(), createdTask.getTitle(), "Название задачи не совпадает");
+        assertEquals(newTask.getDescription(), createdTask.getDescription(), "Описание задачи не совпадает");
+        assertEquals(newTask.getStatus(), createdTask.getStatus(), "Статус задачи не совпадает");
+        assertEquals(newTask.getStartTime(), createdTask.getStartTime(), "Время начала задачи не совпадает");
+        assertEquals(newTask.getDuration(), createdTask.getDuration(), "Длительность задачи не совпадает");
+    }
+
+    @Test
+    void shouldUpdateTask() throws IOException, InterruptedException {
+
+        Task updatedTask = new Task(task.getId(), "Обновленная задача",
+                "Новое описание", Status.DONE,
+                Duration.ofMinutes(120), LocalDateTime.of(2025, 3, 13, 10, 0));
+
+        String requestBody = gson.toJson(updatedTask);
+        HttpResponse<String> response = sendRequest(getTasksUrl(), "POST", requestBody);
+        String responseBody = response.body();
+
+        assertEquals(200, response.statusCode(), "Неверный HTTP-статус");
+
+        Task resultTask = gson.fromJson(responseBody, Task.class);
+
+        assertNotNull(resultTask, "Обновленная задача не должна быть null");
+        assertEquals(updatedTask.getId(), resultTask.getId(), "ID задачи не совпадает");
+        assertEquals(updatedTask.getTitle(), resultTask.getTitle(), "Название задачи не совпадает");
+        assertEquals(updatedTask.getDescription(), resultTask.getDescription(), "Описание задачи не совпадает");
+        assertEquals(updatedTask.getStatus(), resultTask.getStatus(), "Статус задачи не совпадает");
+        assertEquals(updatedTask.getStartTime(), resultTask.getStartTime(), "Время начала задачи не совпадает");
+        assertEquals(updatedTask.getDuration(), resultTask.getDuration(), "Длительность задачи не совпадает");
+    }
+
+    @Test
+    void shouldDeleteTask() throws IOException, InterruptedException {
+        String url = getTasksUrl() + "/" + task.getId();
+        HttpResponse<String> response = sendRequest(url, "DELETE", null);
+
+        assertEquals(200, response.statusCode(), "Неверный HTTP-статус");
+
+        try {
+            taskManager.getTask(task.getId());
+            fail("Должна быть выброшена NotFoundException");
+        } catch (NotFoundException e) {
+            // Ожидаемое поведение
+        }
+
+        HttpResponse<String> responseAfterDelete = sendRequest(url, "GET", null);
+        assertEquals(404, responseAfterDelete.statusCode(),
+                "При получении удаленной задачи должен быть статус 404");
+    }
+
+    // Проверка исключений
+
+    @Test
+    void shouldDeleteNonExistingTask() throws IOException, InterruptedException {
+        String url = getTasksUrl() + "/999";
+        HttpResponse<String> response = sendRequest(url, "DELETE", null);
+
+        assertEquals(404, response.statusCode(),
+                "При попытке удалить несуществующую задачу должен быть статус 404");
+
+        String responseBody = response.body();
+        assertTrue(responseBody.contains("\"error\": \"Ресурс не найден\""),
+                "Ожидалось сообщение об ошибке 'Ресурс не найден'");
+
+        HttpResponse<String> responseAfterDelete = sendRequest(url, "GET", null);
+
+        assertEquals(404, responseAfterDelete.statusCode(),
+                "При получении несуществующей задачи должен быть статус 404");
+    }
+
+    @Test
+    void shouldGetInvalidTaskId() throws IOException, InterruptedException {
+        String url = getTasksUrl() + "/id";
+        HttpResponse<String> response = sendRequest(url, "GET", null);
+
+        assertEquals(400, response.statusCode(),
+                "При некорректном ID задачи должен быть статус 400");
+
+        String responseBody = response.body();
+        assertTrue(responseBody.contains("\"error\": \"Некорректный запрос\""),
+                "Ожидалось сообщение об ошибке 'Некорректный запрос'");
+
+        HttpResponse<String> responseAfter = sendRequest(url, "GET", null);
+
+        assertEquals(400, responseAfter.statusCode(),
+                "При повторном запросе с некорректным ID должен быть статус 400");
+    }
+
+    @Test
+    void shouldPostInvalidTaskWithEmptyBody() throws IOException, InterruptedException {
+        String url = getTasksUrl();
+        HttpResponse<String> response = sendRequest(url, "POST", null);
+
+        assertEquals(400, response.statusCode(),
+                "При некорректной задаче должен быть статус 400");
+
+        String responseBody = response.body();
+        assertTrue(responseBody.contains("\"error\": \"Некорректный запрос\""),
+                "Ожидалось сообщение об ошибке 'Некорректный запрос'");
+
+        HttpResponse<String> responseAfter = sendRequest(url, "POST", null);
+
+        assertEquals(400, responseAfter.statusCode(),
+                "При повторном запросе с некорректной задачей должен быть статус 400");
+    }
+
+
+    @Test
+    void shouldUpdateTaskWithIntersection() throws IOException, InterruptedException {
+        // Создаем вторую задачу с пересекающимся временем
+        Task updateTask = new Task(task.getId(), "прогулка", "ходьба в парке", Status.IN_PROGRESS,
+                Duration.ofHours(2), LocalDateTime.of(2025, 3, 14, 10, 0)
+        );
+
+        String requestBody = gson.toJson(updateTask);
+
+        HttpResponse<String> response = sendRequest(getTasksUrl(), "POST", requestBody);
+
+        assertEquals(409, response.statusCode(), "Должен быть статус 409 при пересечении задач");
+
+        String responseBody = response.body();
+        assertTrue(responseBody.contains("\"error\": \"Пересечение по времени\""),
+                "Ожидалось сообщение об ошибке 'Пересечение по времени'");
+    }
+
+}


### PR DESCRIPTION
Структура проекта:
- Добавлен класс HttpTaskServer для запуска сервера
- Создан базовый класс BaseHttpHandler
- Реализованы обработчики для основных путей API

Функциональность:
- Разработан REST API с маппингом методов TaskManager
- Добавлена поддержка HTTP-методов GET/POST/DELETE
- Добавлена работа с JSON через Gson
- Реализована обработка исключений

Тестирование:
- Добавлены unit-тесты для эндпоинтов
- Добавлена структура тестирования с @BeforeEach/@AfterEach
- Реализованы тесты для успешных и не успешных сценариев